### PR TITLE
feat(normalizeArgs): publish task key as displayName for anonymous functions

### DIFF
--- a/lib/helpers/normalizeArgs.js
+++ b/lib/helpers/normalizeArgs.js
@@ -12,6 +12,9 @@ function normalizeArgs(registry, args){
 
     var fn = registry.get(task);
     assert(fn, 'Task never defined: ' + task);
+    if(!fn.name && !fn.displayName) {
+      fn.displayName = task;
+    }
     return fn;
   }
 


### PR DESCRIPTION
I've been playing with [https://github.com/phated/undertaker-registry](undertaker-registry) to properly modularize gulp-like workflows.

Somehow when loading tasks from theses registry, they end up as anonymous when used with gulp:

```
[17:25:20] Using gulpfile ~/Projects/ng-tools/sandbox-dashboard/gulpfile.js
[17:25:20] Starting 'ng:serve'...
[17:25:20] Starting 'ng:beforeServe'...
[17:25:20] Finished 'ng:beforeServe' after 509 μs
[17:25:20] Starting '<anonymous>'...
[17:25:20] Finished '<anonymous>' after 9.55 ms
[17:25:20] Starting '<anonymous>'...
[17:25:23] gulp-inject 17 files into index.jade.
```

Where it should be:

```
[17:25:42] Using gulpfile ~/Projects/ng-tools/sandbox-dashboard/gulpfile.js
[17:25:42] Starting 'ng:serve'...
[17:25:42] Starting 'ng:beforeServe'...
[17:25:42] Finished 'ng:beforeServe' after 487 μs
[17:25:42] Starting 'ng:src/clean'...
[17:25:42] Finished 'ng:src/clean' after 8.45 ms
[17:25:42] Starting 'ng:src/views'...
[17:25:45] gulp-inject 17 files into index.jade.
```

You can check some of theses registries here:
https://github.com/ng-tools/undertaker-app-tasks/tree/master/lib/tasks

I tried to come up with an unit test for this, but the metadata part where this could be checked does seem totally private.

---

EDIT: I'm using the ConfigRegistry setup showed in your README, maybe the issue is coming from the overriding of the registry set method.

EDIT2: It's not due to that, but can be fixed easily there:

```js
ConfigRegistry.prototype.set = function set(name, fn) {
  this._tasks[name] = fn.bind(this.config);
  this._tasks[name].displayName = name;
  return this._tasks[name];
};
```