### PR TITLE
Prefer `displayName` instead of `name` when both properties are defined

### DIFF
--- a/lib/task.js
+++ b/lib/task.js
@@ -4,7 +4,7 @@ function task(name, fn){
   /* jshint validthis: true */
   if(typeof name === 'function'){
     fn = name;
-    name = fn.name || fn.displayName;
+    name = fn.displayName || fn.name;
   }
 
   if(!fn){

--- a/test/task.js
+++ b/test/task.js
@@ -75,4 +75,12 @@ describe('task', function(){
     expect(taker.task('test1')).to.equal(noop);
     done();
   });
+
+  it('should prefer displayName instead of name when both properties are defined', function(done) {
+    function fn() {}
+    fn.displayName = 'test1';
+    taker.task(fn);
+    expect(taker.task('test1')).to.equal(fn);
+    done();
+  });
 });


### PR DESCRIPTION
Also fixes #29