### PR TITLE
Keep task name precedence consistent

### DIFF
--- a/lib/helpers/buildTree.js
+++ b/lib/helpers/buildTree.js
@@ -11,7 +11,7 @@ function buildTree(tasks){
       return meta.tree;
     }
 
-    var name = task.name || task.displayName || '<anonymous>';
+    var name = task.displayName || task.name || '<anonymous>';
     meta = {
       name: name,
       tree: {


### PR DESCRIPTION
Looking into the way that Undertaker handles task metadata... I can't help but feel that this is slightly fragmented?

This particular PR fixes what I'm pretty sure is just an honest mistake.

Would it make sense to have a shared util for things like mapping task arguments `fn` to `name` and `label` metadata?
