### PR TITLE
Tweak README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ A registry's prototype should define:
 - `set(taskName, fn)`: add task to the registry. If `set` modifies a task, it should return the new task.
 - `tasks()`: returns an object listing all tasks in the registry.
 
+You should not call these functions yourself; leave that to Undertaker, so it can
+keep its metadata consistent.
+
 The easiest way to create a custom registry is to inherit from
 [undertaker-registry](https://www.npmjs.com/package/undertaker-registry):
 
@@ -196,6 +199,7 @@ function CommonRegistry(opts){
 util.inherits(CommonRegistry, DefaultRegistry);
 
 CommonRegistry.prototype.init = function(takerInst){
+  DefaultRegistry.prototype.init.call(this, takerInst);
   var buildDir = this.buildDir;
   var exists = fs.existsSync(buildDir);
 
@@ -229,7 +233,8 @@ taker.task('build', taker.series('clean', function build(cb) {
 By controlling how tasks are added to the registry, you can decorate them.
 
 For example if you wanted all tasks to share some data,  you can use a custom registry
-to bind them to that data:
+to bind them to that data. Be sure to return the altered task, as per the description
+of registry methods above:
 
 ```javascript
 var util = require('util');
@@ -249,8 +254,8 @@ function ConfigRegistry(config){
 util.inherits(ConfigRegistry, DefaultRegistry);
 
 ConfigRegistry.prototype.set = function set(name, fn) {
-  var task = this._tasks[name] = fn.bind(this.config);
-  return task;
+  fn = fn.bind(this.config);
+  return DefaultRegistry.prototype.set.call(this, name, fn) || fn;
 };
 
 var taker = new Undertaker();

--- a/README.md
+++ b/README.md
@@ -199,7 +199,6 @@ function CommonRegistry(opts){
 util.inherits(CommonRegistry, DefaultRegistry);
 
 CommonRegistry.prototype.init = function(takerInst){
-  DefaultRegistry.prototype.init.call(this, takerInst);
   var buildDir = this.buildDir;
   var exists = fs.existsSync(buildDir);
 
@@ -254,8 +253,9 @@ function ConfigRegistry(config){
 util.inherits(ConfigRegistry, DefaultRegistry);
 
 ConfigRegistry.prototype.set = function set(name, fn) {
-  fn = fn.bind(this.config);
-  return DefaultRegistry.prototype.set.call(this, name, fn) || fn;
+  // The `DefaultRegistry` uses `this._tasks` for storage.
+  var task = this._tasks[name] = fn.bind(this.config);
+  return task;
 };
 
 var taker = new Undertaker();


### PR DESCRIPTION
Figured I'd get my promise in [#1319](https://github.com/gulpjs/gulp/issues/1319) out of the way, and align Gulp docs with Undertaker docs with regard to custom registries.

Some minor suggestions here for the latter.

If you like these changes I'll do similarly for Gulp. Otherwise I'll make Gulp align with current Undertaker doc.

It occurred to me that it might be nice to have the DefaultRegistry (https://github.com/phated/undertaker-registry/blob/master/index.js) return a value from `set`, just in case future versions of it want to wrap the function or something? Anyway for now the suggested pattern in this PR doesn't depend on that.