### PR TITLE
Feature bump dependencies

### DIFF
--- a/lib/helpers/metadata.js
+++ b/lib/helpers/metadata.js
@@ -1,9 +1,7 @@
 'use strict';
 
-var WM = require('es6-weak-map');
-var hasNativeWeakMap = require('es6-weak-map/is-native-implemented');
-
 // WeakMap for storing metadata
-var metadata = hasNativeWeakMap ? new WeakMap() : new WM();
+var WM = require('es6-weak-map');
+var metadata = new WM();
 
 module.exports = metadata;

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lib"
   ],
   "scripts": {
-    "test": "lab -cvL"
+    "test": "lab -cvL --ignore store@sparkles"
   },
   "dependencies": {
     "bach": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "bach": "^0.4.1",
-    "es6-weak-map": "^1.0.1",
+    "es6-weak-map": "^2.0.1",
     "last-run": "^1.1.0",
     "lodash": "^3.5.0",
     "undertaker-registry": "0.0.3"
@@ -30,15 +30,14 @@
   "devDependencies": {
     "async-once": "^1.0.0",
     "code": "^1.2.1",
-    "del": "^1.1.1",
+    "del": "^2.0.2",
     "gulp-jshint": "^1.8.4",
-    "lab": "^5.5.0",
+    "lab": "^6.2.0",
     "once": "^1.3.1",
-    "promised-del": "^1.0.2",
-    "through2": "^0.6.3",
+    "through2": "^2.0.0",
     "undertaker-common-tasks": "git://github.com/phated/undertaker-common-tasks",
     "undertaker-task-metadata": "git://github.com/undertakerjs/undertaker-task-metadata",
-    "vinyl-fs": "^1.0.0"
+    "vinyl-fs": "^2.2.0"
   },
   "keywords": [
     "registry",

--- a/test/integration.js
+++ b/test/integration.js
@@ -15,7 +15,6 @@ var spawn = require('child_process').spawn;
 var once = require('once');
 var aOnce = require('async-once');
 var del = require('del');
-var promisedDel = require('promised-del');
 var through = require('through2');
 
 var Undertaker = require('../');
@@ -68,7 +67,7 @@ describe('integrations', function() {
 
     taker.task('clean', once(function() {
       count++;
-      return promisedDel(['./fixtures/some-build.txt'], {cwd: __dirname});
+      return del(['./fixtures/some-build.txt'], {cwd: __dirname});
     }));
 
     taker.task('build-this', taker.series('clean', function(cb){


### PR DESCRIPTION
Noticed that I was getting the WeakMap ponyfill even though I have it natively. That doesn't happen with latest `es6-weak-map`.

Might as well bump some other dependencies too. The one on `promised-del` is no longer needed because latest `del` knows about Promises.